### PR TITLE
Fix listener to work with [EZP-30508]

### DIFF
--- a/EventListener/PreContentViewListener.php
+++ b/EventListener/PreContentViewListener.php
@@ -116,10 +116,10 @@ class PreContentViewListener
 
         if (is_string($viewType) && $location instanceof Location) {
             if ( ( $location->invisible == 1 or $location->hidden == 1 ) and
-                 !( new IsAdmin( $this->siteAccessGroups ) )->isSatisfiedBy(
-                     $this->requestStack->getCurrentRequest()->attributes->get( 'siteaccess' )
-                 ) )
-            {
+                (!( new IsAdmin( $this->siteAccessGroups ) )->isSatisfiedBy(
+                    $this->requestStack->getCurrentRequest()->attributes->get( 'siteaccess' )
+                ) and !$this->requestStack->getCurrentRequest()->attributes->get( 'isPreview' ))
+            ) {
                 throw new NotFoundHttpException( "Page not found" );
             }
 


### PR DESCRIPTION
@ezsystems has made a patch on ezpublish-kernel bundle to fix content preview when a content has hidden relation(s).
However, using this bundle still cause an issue.
Here is a quick fix to not get the "Page not found" exception when is preview mode.

=> https://jira.ez.no/browse/EZP-30508